### PR TITLE
Release v2.0.0 — JobId value object and generic JSON payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to Boomerang are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Versions follow [Semantic Versioning](https://semver.org/).
+
+---
+
+## [Unreleased]
+
+### Planned
+- **Poisoned-well protection (v3.0.0):** Message versioning via a `messageVersion` field on
+  `BoomerangRequest`, surfaced in `SyncContext`. Handlers will be able to declare which versions
+  they support so the framework can reject incompatible messages mid-queue rather than passing
+  them to code that cannot interpret them.
+
+---
+
+## [2.0.0] - 2026-03-25
+
+### Added
+- **`JobId` value object** (`io.github.boomerang.model.JobId`) — replaces the raw `String` in
+  `SyncContext`. Annotated with `@JsonValue` so it serialises as a plain string. Prevents
+  accidentally mixing job IDs with other string-typed values at compile time.
+- **Generic JSON payload** — callers can now include an arbitrary `payload` object in the
+  `POST /jobs` request body. It is stored alongside the job and delivered to the handler via
+  `SyncContext#getPayload()` as a `JsonNode`, ready to read or deserialise to a typed class.
+
+### Changed
+- `SyncContext` now carries `JobId jobId` (was `String jobId`) and the new `JsonNode payload`
+  field. Handlers that previously referenced `ctx.getJobId()` as a `String` should call
+  `ctx.getJobId().toString()` or `ctx.getJobId().value()` where a plain string is needed.
+- `BoomerangRequest` gains a `payload` field (`JsonNode`, nullable).
+- `BoomerangJobRecord` gains a `payload` field (`String` JSON, nullable) persisted in Redis.
+- `BoomerangWorker` now accepts an `ObjectMapper` in its constructor (injected automatically
+  via `boomerangObjectMapper` — no consumer changes required if using the auto-configuration).
+- `boomerang-core` now declares `jackson-databind` as a compile dependency.
+
+---
+
+## [1.0.0] - 2026-03-01
+
+### Added
+- Initial release of Boomerang Spring Boot Starter.
+- `POST /jobs` endpoint — accepts a job and returns `202 Accepted` with a `jobId` in <50 ms.
+- Redis-backed job queue and status store (`boomerang-redis`).
+- `@BoomerangHandler` annotation — marks exactly one method as the async job handler.
+- `SyncContext` — immutable context passed to the handler with `jobId`, `callerId`, and
+  `triggeredAt`.
+- Webhook delivery with exponential-backoff retries and dead-letter storage.
+- HMAC-SHA256 callback signing via `callbackSecret`.
+- Idempotency via `idempotencyKey` with configurable cooldown window.
+- JWT Bearer authentication (`boomerang.auth.jwt-secret`).
+- SSRF protection via callback URL allowlist (`boomerang.callback.allowed-domains`).
+- Job status polling — `GET /jobs/{jobId}` (ownership-enforced).
+- Failed-webhook management — list, replay, and delete dead-lettered deliveries.
+- Micrometer metrics: job counters/timers, webhook counters/timers, queue depth gauge.
+- `boomerang-tests` — Testcontainers + WireMock base class for integration testing.
+- `boomerang-sample` — runnable example Spring Boot application.

--- a/boomerang-core/pom.xml
+++ b/boomerang-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.sameerchereddy</groupId>
         <artifactId>boomerang-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>boomerang-core</artifactId>
@@ -32,6 +32,12 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+
+        <!-- Jackson for JsonNode payload support -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/boomerang-core/src/main/java/io/github/boomerang/model/BoomerangJobRecord.java
+++ b/boomerang-core/src/main/java/io/github/boomerang/model/BoomerangJobRecord.java
@@ -29,6 +29,9 @@ public class BoomerangJobRecord {
     private String result;
     private String error;
 
+    /** Raw JSON string of the caller-supplied payload, or {@code null} if none was provided. */
+    private String payload;
+
     /**
      * Produces a lightweight {@link BoomerangJobStatus} view suitable for the status
      * polling endpoint.
@@ -70,6 +73,9 @@ public class BoomerangJobRecord {
 
         String error = getString(data, "error");
         record.setError((error != null && !error.isBlank()) ? error : null);
+
+        String payload = getString(data, "payload");
+        record.setPayload((payload != null && !payload.isBlank()) ? payload : null);
 
         return record;
     }

--- a/boomerang-core/src/main/java/io/github/boomerang/model/BoomerangRequest.java
+++ b/boomerang-core/src/main/java/io/github/boomerang/model/BoomerangRequest.java
@@ -1,14 +1,13 @@
 package io.github.boomerang.model;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.github.boomerang.validation.ValidCallbackUrl;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 /**
- * Incoming request body for {@code POST /sync}. All fields are optional — when
- * {@code callbackUrl} is absent the caller must poll {@code GET /sync/{jobId}} for the
- * result instead.
+ * Incoming request body for {@code POST /jobs}. All fields are optional except where noted.
  */
 @Data
 public class BoomerangRequest {
@@ -36,4 +35,20 @@ public class BoomerangRequest {
     @Nullable
     @Size(max = 128)
     private String idempotencyKey;
+
+    /**
+     * Arbitrary caller-supplied data. Stored alongside the job and surfaced in
+     * {@link SyncContext#getPayload()} when the handler is invoked, allowing callers
+     * to pass job-specific parameters without a separate lookup.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * {
+     *   "callbackUrl": "https://example.com/hook",
+     *   "payload": { "userId": 42, "reportType": "monthly" }
+     * }
+     * }</pre>
+     */
+    @Nullable
+    private JsonNode payload;
 }

--- a/boomerang-core/src/main/java/io/github/boomerang/model/JobId.java
+++ b/boomerang-core/src/main/java/io/github/boomerang/model/JobId.java
@@ -1,0 +1,28 @@
+package io.github.boomerang.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Objects;
+
+/**
+ * Value object wrapping a job identifier. Using a dedicated type rather than a raw
+ * {@code String} makes handler and API signatures self-documenting and prevents
+ * accidentally mixing job IDs with other string values.
+ *
+ * <p>Annotated with {@link JsonValue} so Jackson serialises it as a plain string
+ * (e.g. {@code "550e8400-e29b-41d4-a716-446655440000"}) rather than as an object.
+ */
+public record JobId(@JsonValue String value) {
+
+    public JobId {
+        Objects.requireNonNull(value, "jobId must not be null");
+        if (value.isBlank()) {
+            throw new IllegalArgumentException("jobId must not be blank");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/boomerang-core/src/main/java/io/github/boomerang/model/SyncContext.java
+++ b/boomerang-core/src/main/java/io/github/boomerang/model/SyncContext.java
@@ -1,5 +1,7 @@
 package io.github.boomerang.model;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -8,18 +10,28 @@ import java.time.Instant;
 /**
  * Immutable context object passed to the {@link io.github.boomerang.annotation.BoomerangHandler}
  * method when a job is being processed. Carries the job identifier, the authenticated caller
- * identifier, and the moment the job was picked up for processing.
+ * identifier, the moment the job was picked up for processing, and the optional caller-supplied
+ * payload.
  */
 @Data
 @AllArgsConstructor
 public class SyncContext {
 
-    /** Unique job identifier (UUID). */
-    private final String jobId;
+    /** Typed job identifier. */
+    private final JobId jobId;
 
     /** JWT subject claim — identifies the authenticated caller that submitted the job. */
     private final String callerId;
 
     /** Timestamp at which the worker started processing this job. */
     private final Instant triggeredAt;
+
+    /**
+     * Caller-supplied payload from {@link BoomerangRequest#getPayload()}, preserved as a
+     * {@link JsonNode} so the handler can read individual fields or deserialise it to a
+     * typed class using an {@code ObjectMapper}. {@code null} when the caller did not
+     * include a payload.
+     */
+    @Nullable
+    private final JsonNode payload;
 }

--- a/boomerang-redis/pom.xml
+++ b/boomerang-redis/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.sameerchereddy</groupId>
         <artifactId>boomerang-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>boomerang-redis</artifactId>

--- a/boomerang-redis/src/main/java/io/github/boomerang/redis/RedisBoomerangJobStore.java
+++ b/boomerang-redis/src/main/java/io/github/boomerang/redis/RedisBoomerangJobStore.java
@@ -49,6 +49,7 @@ public class RedisBoomerangJobStore implements BoomerangJobStore {
         jobData.put("completedAt",    "");
         jobData.put("result",         "");
         jobData.put("error",          "");
+        jobData.put("payload",        req.getPayload() != null ? req.getPayload().toString() : "");
 
         String key = JOB_PREFIX + jobId;
         redisTemplate.opsForHash().putAll(key, jobData);

--- a/boomerang-sample/pom.xml
+++ b/boomerang-sample/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.sameerchereddy</groupId>
         <artifactId>boomerang-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>boomerang-sample</artifactId>

--- a/boomerang-sample/src/main/java/io/github/boomerang/sample/SyncHandler.java
+++ b/boomerang-sample/src/main/java/io/github/boomerang/sample/SyncHandler.java
@@ -1,5 +1,6 @@
 package io.github.boomerang.sample;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.github.boomerang.annotation.BoomerangHandler;
 import io.github.boomerang.model.SyncContext;
 import lombok.extern.slf4j.Slf4j;
@@ -12,26 +13,37 @@ import java.util.Map;
  * Sample Boomerang handler. Simulates a long-running sync operation (3-second sleep)
  * and returns a simple result map. In a real application this would call external APIs,
  * diff data, and write deltas to the local store.
+ *
+ * <p>The caller can pass arbitrary data via the {@code payload} field of the request:
+ * <pre>{@code
+ * {
+ *   "callbackUrl": "https://example.com/hook",
+ *   "payload": { "dataSource": "crm", "since": "2026-01-01" }
+ * }
+ * }</pre>
  */
 @Slf4j
 @Component
 public class SyncHandler {
 
-    /**
-     * The annotated method must accept a single {@link SyncContext} parameter. The return
-     * value is serialised to JSON and delivered to the caller's {@code callbackUrl}.
-     */
     @BoomerangHandler
     public Map<String, Object> doSync(SyncContext ctx) throws InterruptedException {
         log.info("Starting sync for job={} caller={}", ctx.getJobId(), ctx.getCallerId());
+
+        // Read caller-supplied payload fields if present
+        JsonNode payload = ctx.getPayload();
+        String dataSource = (payload != null && payload.has("dataSource"))
+                ? payload.get("dataSource").asText()
+                : "default";
 
         // Simulate slow work — replace with your real sync logic
         Thread.sleep(3_000);
 
         Map<String, Object> result = Map.of(
-                "jobId",      ctx.getJobId(),
-                "callerId",   ctx.getCallerId(),
-                "syncedAt",   Instant.now().toString(),
+                "jobId",         ctx.getJobId(),
+                "callerId",      ctx.getCallerId(),
+                "dataSource",    dataSource,
+                "syncedAt",      Instant.now().toString(),
                 "recordsSynced", 42
         );
 

--- a/boomerang-starter/pom.xml
+++ b/boomerang-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.sameerchereddy</groupId>
         <artifactId>boomerang-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>boomerang-starter</artifactId>

--- a/boomerang-starter/src/main/java/io/github/boomerang/starter/autoconfigure/BoomerangAutoConfiguration.java
+++ b/boomerang-starter/src/main/java/io/github/boomerang/starter/autoconfigure/BoomerangAutoConfiguration.java
@@ -164,9 +164,10 @@ public class BoomerangAutoConfiguration {
                                             BoomerangHandlerRegistry handlerRegistry,
                                             BoomerangWebhookService webhookService,
                                             BoomerangMetrics metrics,
+                                            @Qualifier("boomerangObjectMapper") ObjectMapper objectMapper,
                                             @Qualifier("boomerangTaskExecutor") Executor taskExecutor) {
         return new BoomerangWorker(redisTemplate, jobStore, handlerRegistry,
-                webhookService, metrics, taskExecutor);
+                webhookService, metrics, objectMapper, taskExecutor);
     }
 
     @Bean

--- a/boomerang-starter/src/main/java/io/github/boomerang/starter/service/BoomerangWorker.java
+++ b/boomerang-starter/src/main/java/io/github/boomerang/starter/service/BoomerangWorker.java
@@ -1,6 +1,9 @@
 package io.github.boomerang.starter.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.boomerang.model.BoomerangJobRecord;
+import io.github.boomerang.model.JobId;
 import io.github.boomerang.model.SyncContext;
 import io.github.boomerang.store.BoomerangJobStore;
 import io.github.boomerang.starter.metrics.BoomerangMetrics;
@@ -44,6 +47,7 @@ public class BoomerangWorker {
     private final BoomerangHandlerRegistry handlerRegistry;
     private final BoomerangWebhookService webhookService;
     private final BoomerangMetrics        metrics;
+    private final ObjectMapper            objectMapper;
     private final Executor                taskExecutor;
     private final AtomicBoolean           running = new AtomicBoolean(false);
 
@@ -52,12 +56,14 @@ public class BoomerangWorker {
                            BoomerangHandlerRegistry handlerRegistry,
                            BoomerangWebhookService webhookService,
                            BoomerangMetrics metrics,
+                           @Qualifier("boomerangObjectMapper") ObjectMapper objectMapper,
                            @Qualifier("boomerangTaskExecutor") Executor taskExecutor) {
         this.redisTemplate  = redisTemplate;
         this.jobStore       = jobStore;
         this.handlerRegistry = handlerRegistry;
         this.webhookService = webhookService;
         this.metrics        = metrics;
+        this.objectMapper   = objectMapper;
         this.taskExecutor   = taskExecutor;
     }
 
@@ -141,7 +147,16 @@ public class BoomerangWorker {
         try {
             jobStore.updateStatus(jobId, "IN_PROGRESS", null, null);
 
-            SyncContext ctx = new SyncContext(jobId, job.getOwnerId(), Instant.now());
+            JsonNode payload = null;
+            if (job.getPayload() != null && !job.getPayload().isBlank()) {
+                try {
+                    payload = objectMapper.readTree(job.getPayload());
+                } catch (Exception e) {
+                    log.warn("Could not parse payload JSON for job {} — proceeding with null payload: {}", jobId, e.getMessage());
+                }
+            }
+
+            SyncContext ctx = new SyncContext(new JobId(jobId), job.getOwnerId(), Instant.now(), payload);
             Object result   = handlerRegistry.invoke(ctx);
 
             jobStore.updateStatus(jobId, "DONE", result, null);

--- a/boomerang-tests/pom.xml
+++ b/boomerang-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.sameerchereddy</groupId>
         <artifactId>boomerang-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>boomerang-tests</artifactId>

--- a/boomerang-tests/src/test/java/io/github/boomerang/tests/app/EchoSyncHandler.java
+++ b/boomerang-tests/src/test/java/io/github/boomerang/tests/app/EchoSyncHandler.java
@@ -18,7 +18,7 @@ public class EchoSyncHandler {
     public Map<String, Object> handle(SyncContext ctx) throws InterruptedException {
         Thread.sleep(500);
         return Map.of(
-                "jobId",     ctx.getJobId(),
+                "jobId",     ctx.getJobId().toString(),
                 "callerId",  ctx.getCallerId(),
                 "echoedAt",  Instant.now().toString()
         );

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.github.sameerchereddy</groupId>
     <artifactId>boomerang-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0</version>
     <packaging>pom</packaging>
     <name>Boomerang Parent</name>
     <description>Boomerang Spring Boot Starter - Async Job Processing with Webhooks</description>


### PR DESCRIPTION
## Summary

- **`JobId` value object** — replaces raw `String` in `SyncContext`. Serialises as a plain string via `@JsonValue`. Prevents accidentally passing arbitrary strings where a job ID is expected.
- **Generic JSON payload** — callers can now include a `payload` object in `POST /jobs`. It flows through to `SyncContext#getPayload()` as a `JsonNode`, ready to read or deserialise to a typed class in the handler.
- **Version bump** — all modules bumped to `2.0.0`.
- **`CHANGELOG.md`** — added with entries for v1.0.0, v2.0.0, and an `[Unreleased]` note for the poisoned-well feature planned in v3.0.0.

## Breaking changes

- `SyncContext#getJobId()` now returns `JobId` instead of `String`. Call `.toString()` or `.value()` where a plain string is needed.
- `SyncContext` constructor gains a fourth `JsonNode payload` parameter. Existing handlers compiled against v1.0.0 will need a recompile (the annotation and method signature are otherwise unchanged).

## Test plan

- [x] All 8 integration tests pass (`mvn verify -pl boomerang-tests -am`)
- [x] Full compile clean across all modules