### PR TITLE
Release v4.0.0 — standalone mode and Docker distribution

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,56 @@
+name: Publish Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/boomerang
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build fat jar
+        run: mvn package -pl boomerang-standalone -am -DskipTests --no-transfer-progress
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: boomerang-standalone
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.0.0] - 2026-03-30
+
+### Added
+- **Standalone mode** — jobs can now carry a `workerUrl` field. When present, Boomerang
+  calls the consumer's HTTP endpoint instead of a local `@BoomerangHandler`, captures the
+  response body as the job result, and fires the webhook as normal. Enables thin SDK
+  integrations from any language.
+- **`BoomerangRequest.workerUrl`** — optional HTTPS URL of the consumer's worker endpoint.
+  Subject to the same SSRF allowlist as `callbackUrl`.
+- **`boomerang-standalone` module** — runnable fat-jar service for standalone deployments.
+  Consumers point their `workerUrl` at this service rather than embedding Boomerang.
+  Distributed as a Docker image (`ghcr.io/sameerchereddy/boomerang`).
+- **`Dockerfile`** — non-root Alpine image for production use.
+- **`docker-compose.yml`** — local development stack (Boomerang + Redis).
+- **GitHub Actions workflow** (`.github/workflows/docker-publish.yml`) — builds and pushes
+  the Docker image to GHCR on every `v*` tag.
+- **`boomerang.worker.*` config group** — configures worker invocation behaviour:
+  - `max-attempts` (default `3`) — retry attempts before marking job `FAILED`
+  - `timeout-seconds` (default `300`) — per-attempt HTTP response timeout
+  - `max-response-size-bytes` (default `10485760` / 10 MB) — response body size limit
+- **`boomerang.worker.invocations` metric** — counts standalone-mode dispatches.
+- **`boomerang.worker.invocation.failures` metric** — counts exhausted worker retries.
+- **`BoomerangIntegrationTestBase` worker helpers** — `stubWorkerUrl`, `stubWorkerUrlWithFailure`,
+  `verifyWorkerCalledWithJobId`, `verifyWorkerSignaturePresent` for standalone mode tests.
+- **`BoomerangStandaloneModeIT`** — 12-scenario compliance test suite for standalone mode.
+
+### Changed
+- `@BoomerangHandler` is no longer required at startup. Applications with no handler log
+  an info message and boot cleanly, operating in standalone-only mode. Jobs without a
+  `workerUrl` and without a registered handler will fail at processing time with a clear
+  error message.
+- `BoomerangWebhookService` HMAC logic extracted to package-private `BoomerangHmacUtils`
+  and reused by `StandaloneWorkerInvoker` — no behaviour change.
+- `BoomerangWorker` accepts `StandaloneWorkerInvoker` as a constructor dependency
+  (injected automatically via auto-configuration — no consumer changes required).
+- Dedicated `boomerangWorkerRestClient` bean with a configurable response timeout separate
+  from the webhook client.
+
+---
+
 ## [3.0.0] - 2026-03-25
 
 ### Added

--- a/boomerang-core/src/main/java/io/github/boomerang/model/BoomerangJobRecord.java
+++ b/boomerang-core/src/main/java/io/github/boomerang/model/BoomerangJobRecord.java
@@ -36,6 +36,12 @@ public class BoomerangJobRecord {
     private String messageVersion;
 
     /**
+     * Consumer's worker endpoint URL for standalone mode, or {@code null} for embedded mode.
+     * When non-null, Boomerang POSTs the job payload here instead of invoking a local handler.
+     */
+    private String workerUrl;
+
+    /**
      * Produces a lightweight {@link BoomerangJobStatus} view suitable for the status
      * polling endpoint.
      */
@@ -82,6 +88,9 @@ public class BoomerangJobRecord {
 
         String messageVersion = getString(data, "messageVersion");
         record.setMessageVersion((messageVersion != null && !messageVersion.isBlank()) ? messageVersion : null);
+
+        String workerUrl = getString(data, "workerUrl");
+        record.setWorkerUrl((workerUrl != null && !workerUrl.isBlank()) ? workerUrl : null);
 
         return record;
     }

--- a/boomerang-core/src/main/java/io/github/boomerang/model/BoomerangRequest.java
+++ b/boomerang-core/src/main/java/io/github/boomerang/model/BoomerangRequest.java
@@ -62,4 +62,16 @@ public class BoomerangRequest {
     @Nullable
     @Size(max = 64)
     private String messageVersion;
+
+    /**
+     * HTTPS URL of the consumer's worker endpoint. When present, Boomerang operates in
+     * <em>standalone mode</em>: instead of invoking a local {@code @BoomerangHandler}
+     * method, it POSTs the job payload to this URL and captures the response body as the
+     * job result. Subject to the same SSRF allowlist as {@code callbackUrl}.
+     *
+     * <p>When absent, Boomerang falls back to <em>embedded mode</em> and invokes the
+     * registered {@code @BoomerangHandler} method within the same JVM.
+     */
+    @Nullable
+    private String workerUrl;
 }

--- a/boomerang-redis/src/main/java/io/github/boomerang/redis/RedisBoomerangJobStore.java
+++ b/boomerang-redis/src/main/java/io/github/boomerang/redis/RedisBoomerangJobStore.java
@@ -51,6 +51,7 @@ public class RedisBoomerangJobStore implements BoomerangJobStore {
         jobData.put("error",          "");
         jobData.put("payload",        req.getPayload()        != null ? req.getPayload().toString()        : "");
         jobData.put("messageVersion", req.getMessageVersion() != null ? req.getMessageVersion()             : "");
+        jobData.put("workerUrl",      req.getWorkerUrl()      != null ? req.getWorkerUrl()                  : "");
 
         String key = JOB_PREFIX + jobId;
         redisTemplate.opsForHash().putAll(key, jobData);

--- a/boomerang-standalone/Dockerfile
+++ b/boomerang-standalone/Dockerfile
@@ -1,0 +1,16 @@
+FROM eclipse-temurin:17-jre-alpine
+
+# Add non-root user for security
+RUN addgroup -S boomerang && adduser -S boomerang -G boomerang
+
+WORKDIR /app
+
+ARG JAR_FILE=target/boomerang-standalone-*.jar
+COPY ${JAR_FILE} app.jar
+
+RUN chown boomerang:boomerang app.jar
+USER boomerang
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/boomerang-standalone/README.md
+++ b/boomerang-standalone/README.md
@@ -1,0 +1,135 @@
+# boomerang-standalone
+
+Runnable Boomerang service for **standalone mode**. Deploy this as infrastructure and point any application's `workerUrl` at it — regardless of language or framework.
+
+Unlike the embedded library (`boomerang-starter`), this module contains no `@BoomerangHandler`. All job dispatch happens over HTTP: Boomerang calls your `workerUrl`, captures the response, and fires the webhook callback. Your application never needs to pull in the Java library.
+
+---
+
+## Quick start
+
+```bash
+docker compose up
+```
+
+This starts Boomerang on port `8080` and Redis on port `6379`. Edit `docker-compose.yml` to set your JWT secret and allowed domains before running in anything beyond local dev.
+
+---
+
+## Docker
+
+The image is published to GitHub Container Registry on every `v*` tag:
+
+```bash
+docker pull ghcr.io/sameerchereddy/boomerang:latest
+```
+
+Run it directly:
+
+```bash
+docker run -d \
+  -p 8080:8080 \
+  -e BOOMERANG_JWT_SECRET=your-secret-min-32-chars \
+  -e SPRING_DATA_REDIS_HOST=your-redis-host \
+  -e BOOMERANG_CALLBACK_ALLOWED_DOMAINS=myapp.example.com \
+  ghcr.io/sameerchereddy/boomerang:latest
+```
+
+---
+
+## How it works
+
+```
+Your app  →  POST /sync  { workerUrl, callbackUrl, ... }
+                ↓  202 + jobId  (< 50 ms)
+            [Boomerang queues job]
+                ↓  POST workerUrl  { jobId, triggeredAt }
+            Your app processes and returns result in HTTP response body
+                ↓  POST callbackUrl  { jobId, status, result }
+```
+
+1. Your app triggers a job by POSTing to `/sync` with a `workerUrl` pointing at your own endpoint.
+2. Boomerang returns `202` immediately with a `jobId`.
+3. Boomerang calls your `workerUrl` — you process the work and return the result as the HTTP response body.
+4. Boomerang fires your `callbackUrl` with the result.
+
+---
+
+## Triggering a job
+
+```bash
+curl -X POST http://localhost:8080/sync \
+  -H "Authorization: Bearer <jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "workerUrl":      "https://myapp.example.com/internal/do-sync",
+    "callbackUrl":    "https://myapp.example.com/hooks/sync-done",
+    "callbackSecret": "optional-hmac-secret-min-32-chars",
+    "idempotencyKey": "optional-dedup-key",
+    "payload":        { "any": "data" }
+  }'
+# → 202 { "jobId": "..." }
+```
+
+## Worker endpoint contract
+
+Boomerang calls your `workerUrl` with:
+
+```
+POST https://myapp.example.com/internal/do-sync
+X-Boomerang-Job-Id:  <jobId>
+X-Signature-SHA256:  sha256=<hmac-hex>   (only when callbackSecret was provided)
+Content-Type:        application/json
+
+{ "jobId": "...", "triggeredAt": "2026-03-30T10:00:00Z" }
+```
+
+- Return **any 2xx** — Boomerang captures the response body as the job result.
+- Return **any non-2xx** — Boomerang retries up to `boomerang.worker.max-attempts` times, then marks the job `FAILED` and fires the callback with `"status": "FAILED"`.
+
+---
+
+## Configuration
+
+All settings are driven by environment variables. Full list:
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `BOOMERANG_JWT_SECRET` | *(required)* | HS256 signing secret — min 32 chars |
+| `SPRING_DATA_REDIS_HOST` | `localhost` | Redis hostname |
+| `SPRING_DATA_REDIS_PORT` | `6379` | Redis port |
+| `BOOMERANG_CALLBACK_ALLOWED_DOMAINS` | *(empty)* | Comma-separated allowed domains for `callbackUrl` and `workerUrl` |
+| `BOOMERANG_SKIP_URL_VALIDATION` | `false` | Bypass SSRF checks — local dev only |
+| `BOOMERANG_IDEMPOTENCY_COOLDOWN_SECONDS` | `300` | Duplicate request window |
+| `BOOMERANG_THREAD_POOL_CORE_SIZE` | `5` | Worker thread pool core size |
+| `BOOMERANG_THREAD_POOL_MAX_SIZE` | `20` | Worker thread pool max size |
+| `BOOMERANG_THREAD_POOL_QUEUE_CAPACITY` | `100` | Jobs queued before pool rejects |
+| `BOOMERANG_WEBHOOK_MAX_ATTEMPTS` | `5` | Callback delivery retry attempts |
+| `BOOMERANG_WEBHOOK_INITIAL_BACKOFF_MS` | `1000` | Initial retry backoff (ms) |
+| `BOOMERANG_WEBHOOK_MAX_BACKOFF_MS` | `30000` | Max retry backoff (ms) |
+| `BOOMERANG_WORKER_MAX_ATTEMPTS` | `3` | Worker invocation retry attempts |
+| `BOOMERANG_WORKER_TIMEOUT_SECONDS` | `300` | Per-attempt timeout for worker calls |
+| `BOOMERANG_WORKER_MAX_RESPONSE_SIZE_BYTES` | `10485760` | Max worker response body size (10 MB) |
+
+---
+
+## API
+
+Base path is `/sync`. All endpoints require `Authorization: Bearer <jwt>`.
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/sync` | Enqueue a job — returns `202 { jobId }` |
+| `GET` | `/sync/{jobId}` | Poll job status |
+| `GET` | `/sync/failed-webhooks` | List dead-lettered webhook deliveries |
+| `POST` | `/sync/failed-webhooks/{jobId}/replay` | Re-attempt a failed delivery |
+| `DELETE` | `/sync/failed-webhooks/{jobId}` | Discard a failed delivery |
+
+---
+
+## Building the image locally
+
+```bash
+mvn package -pl boomerang-standalone -am -DskipTests
+docker build -t boomerang:local boomerang-standalone/
+```

--- a/boomerang-standalone/docker-compose.yml
+++ b/boomerang-standalone/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  boomerang:
+    image: ghcr.io/sameerchereddy/boomerang:latest
+    ports:
+      - "8080:8080"
+    environment:
+      BOOMERANG_JWT_SECRET: dev-secret-change-me-must-be-32-chars
+      SPRING_DATA_REDIS_HOST: redis
+      BOOMERANG_CALLBACK_ALLOWED_DOMAINS: localhost,host.docker.internal
+      BOOMERANG_SKIP_URL_VALIDATION: "false"
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5

--- a/boomerang-standalone/pom.xml
+++ b/boomerang-standalone/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.github.sameerchereddy</groupId>
+        <artifactId>boomerang-parent</artifactId>
+        <version>3.0.0</version>
+    </parent>
+
+    <artifactId>boomerang-standalone</artifactId>
+    <name>Boomerang Standalone</name>
+    <description>
+        Runnable Boomerang service for standalone mode. Produces a fat jar and Docker image.
+        Consumers point their workerUrl at this service rather than embedding Boomerang in their app.
+    </description>
+
+    <properties>
+        <!-- Not a publishable library — skip Maven Central deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.sameerchereddy</groupId>
+            <artifactId>boomerang-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Repackage as fat jar for Docker distribution -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/boomerang-standalone/src/main/java/io/github/boomerang/standalone/StandaloneApp.java
+++ b/boomerang-standalone/src/main/java/io/github/boomerang/standalone/StandaloneApp.java
@@ -1,0 +1,33 @@
+package io.github.boomerang.standalone;
+
+import io.github.boomerang.starter.annotation.EnableBoomerang;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Runnable Boomerang service for standalone mode.
+ *
+ * <p>This application intentionally contains no {@code @BoomerangHandler} method.
+ * All jobs are expected to carry a {@code workerUrl} — Boomerang calls the consumer's
+ * existing endpoint over HTTP to perform the work, then fires the webhook callback.
+ *
+ * <p>Minimum required environment variables:
+ * <pre>
+ *   BOOMERANG_JWT_SECRET              HS256 signing secret (min 32 chars)
+ *   SPRING_DATA_REDIS_HOST            Redis hostname (default: localhost)
+ *   BOOMERANG_CALLBACK_ALLOWED_DOMAINS  Comma-separated allowed callback/worker domains
+ * </pre>
+ *
+ * <p>Quick start with Docker Compose:
+ * <pre>
+ *   docker compose -f boomerang-standalone/docker-compose.yml up
+ * </pre>
+ */
+@SpringBootApplication
+@EnableBoomerang
+public class StandaloneApp {
+
+    public static void main(String[] args) {
+        SpringApplication.run(StandaloneApp.class, args);
+    }
+}

--- a/boomerang-standalone/src/main/resources/application.yml
+++ b/boomerang-standalone/src/main/resources/application.yml
@@ -1,0 +1,49 @@
+server:
+  port: 8080
+
+spring:
+  data:
+    redis:
+      host: ${SPRING_DATA_REDIS_HOST:localhost}
+      port: ${SPRING_DATA_REDIS_PORT:6379}
+
+boomerang:
+  base-path: /sync
+  job-ttl-days: 7
+  failed-webhook-ttl-days: 30
+
+  auth:
+    jwt-secret: ${BOOMERANG_JWT_SECRET}
+
+  callback:
+    # Comma-separated list of allowed domains for both callbackUrl and workerUrl.
+    # Example: allowed-domains: myapp.com,internal.myorg.com
+    allowed-domains: ${BOOMERANG_CALLBACK_ALLOWED_DOMAINS:}
+    skip-validation: ${BOOMERANG_SKIP_URL_VALIDATION:false}
+
+  idempotency:
+    cooldown-seconds: ${BOOMERANG_IDEMPOTENCY_COOLDOWN_SECONDS:300}
+
+  thread-pool:
+    core-size: ${BOOMERANG_THREAD_POOL_CORE_SIZE:5}
+    max-size: ${BOOMERANG_THREAD_POOL_MAX_SIZE:20}
+    queue-capacity: ${BOOMERANG_THREAD_POOL_QUEUE_CAPACITY:100}
+
+  webhook:
+    max-attempts: ${BOOMERANG_WEBHOOK_MAX_ATTEMPTS:5}
+    initial-backoff-ms: ${BOOMERANG_WEBHOOK_INITIAL_BACKOFF_MS:1000}
+    max-backoff-ms: ${BOOMERANG_WEBHOOK_MAX_BACKOFF_MS:30000}
+
+  worker:
+    max-attempts: ${BOOMERANG_WORKER_MAX_ATTEMPTS:3}
+    timeout-seconds: ${BOOMERANG_WORKER_TIMEOUT_SECONDS:300}
+    max-response-size-bytes: ${BOOMERANG_WORKER_MAX_RESPONSE_SIZE_BYTES:10485760}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      show-details: always

--- a/boomerang-starter/src/main/java/io/github/boomerang/starter/autoconfigure/BoomerangAutoConfiguration.java
+++ b/boomerang-starter/src/main/java/io/github/boomerang/starter/autoconfigure/BoomerangAutoConfiguration.java
@@ -14,9 +14,12 @@ import io.github.boomerang.starter.registry.BoomerangHandlerRegistry;
 import io.github.boomerang.starter.security.BoomerangSecurityConfig;
 import io.github.boomerang.starter.service.BoomerangWebhookService;
 import io.github.boomerang.starter.service.BoomerangWorker;
+import io.github.boomerang.starter.service.StandaloneWorkerInvoker;
 import io.github.boomerang.starter.validation.BoomerangCallbackUrlValidator;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.util.Timeout;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -75,6 +78,28 @@ public class BoomerangAutoConfiguration {
     public RestClient boomerangRestClient() {
         HttpComponentsClientHttpRequestFactory factory =
                 new HttpComponentsClientHttpRequestFactory(HttpClients.createDefault());
+        return RestClient.builder()
+                .requestFactory(factory)
+                .build();
+    }
+
+    /**
+     * Dedicated {@link RestClient} for worker invocations in standalone mode. Uses a
+     * separate Apache HttpClient configured with a long response timeout derived from
+     * {@code boomerang.worker.timeout-seconds} to support long-running jobs without
+     * affecting the webhook client's timeout settings.
+     */
+    @Bean("boomerangWorkerRestClient")
+    @ConditionalOnMissingBean(name = "boomerangWorkerRestClient")
+    public RestClient boomerangWorkerRestClient(BoomerangProperties props) {
+        int timeoutSeconds = props.getWorker().getTimeoutSeconds();
+        org.apache.hc.client5.http.config.RequestConfig requestConfig =
+                org.apache.hc.client5.http.config.RequestConfig.custom()
+                        .setResponseTimeout(Timeout.ofSeconds(timeoutSeconds))
+                        .build();
+        HttpComponentsClientHttpRequestFactory factory =
+                new HttpComponentsClientHttpRequestFactory(
+                        HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build());
         return RestClient.builder()
                 .requestFactory(factory)
                 .build();
@@ -158,16 +183,28 @@ public class BoomerangAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(StandaloneWorkerInvoker.class)
+    public StandaloneWorkerInvoker standaloneWorkerInvoker(
+            @Qualifier("boomerangWorkerRestClient") RestClient workerRestClient,
+            @Qualifier("boomerangObjectMapper") ObjectMapper objectMapper,
+            BoomerangProperties props) {
+        BoomerangProperties.Worker w = props.getWorker();
+        return new StandaloneWorkerInvoker(workerRestClient, objectMapper,
+                w.getMaxAttempts(), w.getMaxResponseSizeBytes());
+    }
+
+    @Bean
     @ConditionalOnMissingBean(BoomerangWorker.class)
     public BoomerangWorker boomerangWorker(StringRedisTemplate redisTemplate,
                                             BoomerangJobStore jobStore,
                                             BoomerangHandlerRegistry handlerRegistry,
                                             BoomerangWebhookService webhookService,
+                                            StandaloneWorkerInvoker standaloneWorkerInvoker,
                                             BoomerangMetrics metrics,
                                             @Qualifier("boomerangObjectMapper") ObjectMapper objectMapper,
                                             @Qualifier("boomerangTaskExecutor") Executor taskExecutor) {
         return new BoomerangWorker(redisTemplate, jobStore, handlerRegistry,
-                webhookService, metrics, objectMapper, taskExecutor);
+                webhookService, standaloneWorkerInvoker, metrics, objectMapper, taskExecutor);
     }
 
     @Bean

--- a/boomerang-starter/src/main/java/io/github/boomerang/starter/config/BoomerangProperties.java
+++ b/boomerang-starter/src/main/java/io/github/boomerang/starter/config/BoomerangProperties.java
@@ -19,6 +19,7 @@ public class BoomerangProperties {
     private Idempotency idempotency = new Idempotency();
     private ThreadPool  threadPool  = new ThreadPool();
     private Webhook     webhook     = new Webhook();
+    private Worker      worker      = new Worker();
 
     /**
      * Base URL path for all Boomerang endpoints. Override to match your domain language —
@@ -107,5 +108,27 @@ public class BoomerangProperties {
          * Maximum backoff interval in milliseconds. Default: 30000 (30 s).
          */
         private long maxBackoffMs = 30_000;
+    }
+
+    @Data
+    public static class Worker {
+        /**
+         * Maximum number of HTTP call attempts to the {@code workerUrl} before the job
+         * is marked {@code FAILED}. Default: 3.
+         */
+        private int maxAttempts = 3;
+
+        /**
+         * Per-attempt HTTP response timeout in seconds when calling the {@code workerUrl}.
+         * Long-running jobs should increase this. Default: 300 (5 minutes).
+         */
+        private int timeoutSeconds = 300;
+
+        /**
+         * Maximum response body size in bytes accepted from the {@code workerUrl}.
+         * Responses exceeding this limit cause the job to be marked {@code FAILED}.
+         * Default: 10485760 (10 MB).
+         */
+        private int maxResponseSizeBytes = 10 * 1024 * 1024;
     }
 }

--- a/boomerang-starter/src/main/java/io/github/boomerang/starter/controller/BoomerangController.java
+++ b/boomerang-starter/src/main/java/io/github/boomerang/starter/controller/BoomerangController.java
@@ -79,10 +79,14 @@ public class BoomerangController {
     public ResponseEntity<?> triggerSync(@Valid @RequestBody BoomerangRequest req,
                                          @AuthenticationPrincipal String callerId) {
 
-        // 1. SSRF allowlist check
+        // 1. SSRF allowlist checks
         if (req.getCallbackUrl() != null && !callbackUrlValidator.isAllowed(req.getCallbackUrl())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
                     .body(Map.of("error", "Callback URL not in allowlist"));
+        }
+        if (req.getWorkerUrl() != null && !callbackUrlValidator.isAllowed(req.getWorkerUrl())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", "Worker URL not in allowlist"));
         }
 
         // 2. Acquire per-caller idempotency lock (SET NX EX)

--- a/boomerang-starter/src/main/java/io/github/boomerang/starter/metrics/BoomerangMetrics.java
+++ b/boomerang-starter/src/main/java/io/github/boomerang/starter/metrics/BoomerangMetrics.java
@@ -29,6 +29,8 @@ public class BoomerangMetrics {
     public final Counter webhookSuccesses;
     public final Counter webhookFailures;
     public final Counter poolRejections;
+    public final Counter workerInvocations;
+    public final Counter workerInvocationFailures;
     public final Timer   jobDuration;
     public final Timer   webhookDuration;
 
@@ -59,6 +61,14 @@ public class BoomerangMetrics {
 
         poolRejections = Counter.builder("boomerang.pool.rejections")
                 .description("Jobs rejected by the worker thread pool and re-queued for later processing")
+                .register(registry);
+
+        workerInvocations = Counter.builder("boomerang.worker.invocations")
+                .description("Standalone-mode jobs dispatched to a workerUrl")
+                .register(registry);
+
+        workerInvocationFailures = Counter.builder("boomerang.worker.invocation.failures")
+                .description("Standalone-mode worker invocations that failed after all retries")
                 .register(registry);
 
         jobDuration = Timer.builder("boomerang.job.duration")

--- a/boomerang-starter/src/main/java/io/github/boomerang/starter/registry/BoomerangHandlerRegistry.java
+++ b/boomerang-starter/src/main/java/io/github/boomerang/starter/registry/BoomerangHandlerRegistry.java
@@ -13,13 +13,15 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 /**
- * Scans the application context after startup for exactly one method annotated with
+ * Scans the application context after startup for a method annotated with
  * {@link BoomerangHandler} and holds a reference to it for reflective invocation by the
  * worker. Scanning is deferred to {@link ContextRefreshedEvent} so that all beans —
  * including those created by auto-configurations — are fully initialised before the scan.
  *
- * <p>Throws {@link IllegalStateException} at startup if zero or more than one handler
- * method is found.
+ * <p>Finding exactly one handler registers embedded mode. Finding zero handlers is
+ * permitted — the application is assumed to operate in standalone mode where jobs carry
+ * a {@code workerUrl}. Finding more than one handler throws {@link IllegalStateException}
+ * at startup.
  */
 @Slf4j
 public class BoomerangHandlerRegistry {
@@ -70,9 +72,9 @@ public class BoomerangHandlerRegistry {
         }
 
         if (foundMethod == null) {
-            throw new IllegalStateException(
-                    "@EnableBoomerang requires exactly one @BoomerangHandler method in the " +
-                    "application context. Please annotate your handler method with @BoomerangHandler.");
+            log.info("No @BoomerangHandler found — running in standalone mode. " +
+                     "All jobs must supply a workerUrl.");
+            return;
         }
 
         this.handlerBean   = foundBean;
@@ -87,9 +89,15 @@ public class BoomerangHandlerRegistry {
      * @return the handler's return value (may be {@code null} for void methods)
      * @throws Exception any exception thrown by the handler
      */
+    public boolean hasHandler() {
+        return handlerMethod != null;
+    }
+
     public Object invoke(SyncContext ctx) throws Exception {
         if (handlerMethod == null) {
-            throw new IllegalStateException("BoomerangHandlerRegistry has not been initialised yet");
+            throw new IllegalStateException(
+                    "No @BoomerangHandler registered. This job has no workerUrl — either add " +
+                    "a @BoomerangHandler method (embedded mode) or supply a workerUrl in the request.");
         }
         try {
             return handlerMethod.invoke(handlerBean, ctx);

--- a/boomerang-starter/src/main/java/io/github/boomerang/starter/service/BoomerangHmacUtils.java
+++ b/boomerang-starter/src/main/java/io/github/boomerang/starter/service/BoomerangHmacUtils.java
@@ -1,0 +1,38 @@
+package io.github.boomerang.starter.service;
+
+import org.apache.commons.codec.binary.Hex;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Package-private utility for computing HmacSHA256 signatures used by both
+ * {@link BoomerangWebhookService} (outgoing webhooks) and
+ * {@link StandaloneWorkerInvoker} (outgoing worker invocations).
+ *
+ * <p>The signature format is {@code sha256=<lowercase hex>} as specified by the
+ * Boomerang cross-language contract.
+ */
+final class BoomerangHmacUtils {
+
+    private BoomerangHmacUtils() {}
+
+    /**
+     * Computes {@code sha256=<lowercase hex>} over the given body string using the
+     * provided secret.
+     *
+     * @param body   raw payload string (UTF-8 encoded for HMAC input)
+     * @param secret HMAC secret
+     * @return full signature header value, e.g. {@code sha256=abc123...}
+     */
+    static String sign(String body, String secret) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return "sha256=" + Hex.encodeHexString(mac.doFinal(body.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to compute HMAC-SHA256 signature", e);
+        }
+    }
+}

--- a/boomerang-starter/src/main/java/io/github/boomerang/starter/service/BoomerangWebhookService.java
+++ b/boomerang-starter/src/main/java/io/github/boomerang/starter/service/BoomerangWebhookService.java
@@ -6,15 +6,11 @@ import io.github.boomerang.model.BoomerangPayload;
 import io.github.boomerang.redis.BoomerangFailedWebhookStore;
 import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.codec.binary.Hex;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.client.RestClient;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 
 /**
@@ -104,13 +100,8 @@ public class BoomerangWebhookService {
     }
 
     private String hmacSha256(String body, String secret) {
-        try {
-            Mac mac = Mac.getInstance("HmacSHA256");
-            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
-            return Hex.encodeHexString(mac.doFinal(body.getBytes(StandardCharsets.UTF_8)));
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to compute HMAC-SHA256 signature", e);
-        }
+        // Strip the "sha256=" prefix — callers append it themselves
+        return BoomerangHmacUtils.sign(body, secret).substring("sha256=".length());
     }
 
     private String toJson(Object value) {

--- a/boomerang-starter/src/main/java/io/github/boomerang/starter/service/BoomerangWorker.java
+++ b/boomerang-starter/src/main/java/io/github/boomerang/starter/service/BoomerangWorker.java
@@ -42,29 +42,32 @@ public class BoomerangWorker {
     private static final String PENDING_QUEUE = "boomerang-jobs:pending";
     private static final String JOB_PREFIX    = "boomerang-job:";
 
-    private final StringRedisTemplate     redisTemplate;
-    private final BoomerangJobStore       jobStore;
-    private final BoomerangHandlerRegistry handlerRegistry;
-    private final BoomerangWebhookService webhookService;
-    private final BoomerangMetrics        metrics;
-    private final ObjectMapper            objectMapper;
-    private final Executor                taskExecutor;
-    private final AtomicBoolean           running = new AtomicBoolean(false);
+    private final StringRedisTemplate       redisTemplate;
+    private final BoomerangJobStore         jobStore;
+    private final BoomerangHandlerRegistry  handlerRegistry;
+    private final BoomerangWebhookService   webhookService;
+    private final StandaloneWorkerInvoker   workerInvoker;
+    private final BoomerangMetrics          metrics;
+    private final ObjectMapper              objectMapper;
+    private final Executor                  taskExecutor;
+    private final AtomicBoolean             running = new AtomicBoolean(false);
 
     public BoomerangWorker(StringRedisTemplate redisTemplate,
                            BoomerangJobStore jobStore,
                            BoomerangHandlerRegistry handlerRegistry,
                            BoomerangWebhookService webhookService,
+                           StandaloneWorkerInvoker workerInvoker,
                            BoomerangMetrics metrics,
                            @Qualifier("boomerangObjectMapper") ObjectMapper objectMapper,
                            @Qualifier("boomerangTaskExecutor") Executor taskExecutor) {
-        this.redisTemplate  = redisTemplate;
-        this.jobStore       = jobStore;
+        this.redisTemplate   = redisTemplate;
+        this.jobStore        = jobStore;
         this.handlerRegistry = handlerRegistry;
-        this.webhookService = webhookService;
-        this.metrics        = metrics;
-        this.objectMapper   = objectMapper;
-        this.taskExecutor   = taskExecutor;
+        this.webhookService  = webhookService;
+        this.workerInvoker   = workerInvoker;
+        this.metrics         = metrics;
+        this.objectMapper    = objectMapper;
+        this.taskExecutor    = taskExecutor;
     }
 
     /**
@@ -157,7 +160,17 @@ public class BoomerangWorker {
             }
 
             SyncContext ctx = new SyncContext(new JobId(jobId), job.getOwnerId(), Instant.now(), payload, job.getMessageVersion());
-            Object result   = handlerRegistry.invoke(ctx);
+
+            Object result;
+            if (job.getWorkerUrl() != null && !job.getWorkerUrl().isBlank()) {
+                // Standalone mode: call the consumer's workerUrl over HTTP
+                log.debug("Job {} dispatching to workerUrl: {}", jobId, job.getWorkerUrl());
+                metrics.workerInvocations.increment();
+                result = workerInvoker.invoke(job.getWorkerUrl(), jobId, secret, ctx.getTriggeredAt());
+            } else {
+                // Embedded mode: invoke the registered @BoomerangHandler within this JVM
+                result = handlerRegistry.invoke(ctx);
+            }
 
             jobStore.updateStatus(jobId, "DONE", result, null);
             metrics.jobsCompleted.increment();
@@ -173,6 +186,9 @@ public class BoomerangWorker {
             log.error("Job {} failed: {}", jobId, e.getMessage(), e);
             jobStore.updateStatus(jobId, "FAILED", null, e.getMessage());
             metrics.jobsFailed.increment();
+            if (job.getWorkerUrl() != null && !job.getWorkerUrl().isBlank()) {
+                metrics.workerInvocationFailures.increment();
+            }
             metrics.jobDuration.record(Duration.between(start, Instant.now()));
 
             if (callbackUrl != null && !callbackUrl.isBlank()) {

--- a/boomerang-starter/src/main/java/io/github/boomerang/starter/service/StandaloneWorkerInvoker.java
+++ b/boomerang-starter/src/main/java/io/github/boomerang/starter/service/StandaloneWorkerInvoker.java
@@ -1,0 +1,130 @@
+package io.github.boomerang.starter.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.web.client.RestClient;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Invokes the consumer's {@code workerUrl} endpoint in standalone mode. Boomerang POSTs
+ * the job payload to the URL, captures the response body as the job result, and returns
+ * it to the caller. Retries on failure using a fixed-delay {@link RetryTemplate}.
+ *
+ * <p>The outgoing request follows the Boomerang worker invocation contract:
+ * <ul>
+ *   <li>{@code X-Boomerang-Job-Id} — the job identifier</li>
+ *   <li>{@code X-Signature-SHA256} — HmacSHA256 signature over the body (only when a
+ *       {@code callbackSecret} was provided with the original request)</li>
+ *   <li>{@code Content-Type: application/json}</li>
+ *   <li>Body: {@code { "jobId": "...", "triggeredAt": "..." }}</li>
+ * </ul>
+ *
+ * <p>Any 2xx response is treated as success; the response body is returned as the result.
+ * Any non-2xx causes a {@link WorkerInvocationException}, which {@link BoomerangWorker}
+ * catches and uses to mark the job {@code FAILED}.
+ */
+@Slf4j
+public class StandaloneWorkerInvoker {
+
+    private final RestClient   restClient;
+    private final ObjectMapper objectMapper;
+    private final int          maxAttempts;
+    private final int          maxResponseSizeBytes;
+
+    public StandaloneWorkerInvoker(@Qualifier("boomerangWorkerRestClient") RestClient restClient,
+                                   @Qualifier("boomerangObjectMapper") ObjectMapper objectMapper,
+                                   int maxAttempts,
+                                   int maxResponseSizeBytes) {
+        this.restClient          = restClient;
+        this.objectMapper        = objectMapper;
+        this.maxAttempts         = maxAttempts;
+        this.maxResponseSizeBytes = maxResponseSizeBytes;
+    }
+
+    /**
+     * Calls the {@code workerUrl} and returns the response body as a String.
+     *
+     * @param workerUrl     consumer's worker endpoint
+     * @param jobId         job identifier
+     * @param secret        HMAC secret for signing; {@code null} to skip signing
+     * @param triggeredAt   job trigger timestamp
+     * @return response body from the worker (used as job result)
+     * @throws WorkerInvocationException if all attempts are exhausted or the response is too large
+     */
+    public String invoke(String workerUrl, String jobId, String secret, Instant triggeredAt) {
+        String body = buildRequestBody(jobId, triggeredAt);
+
+        String signature = (secret != null && !secret.isBlank())
+                ? BoomerangHmacUtils.sign(body, secret)
+                : null;
+
+        RetryTemplate retry = RetryTemplate.builder()
+                .maxAttempts(maxAttempts)
+                .fixedBackoff(2_000)
+                .build();
+
+        try {
+            return retry.execute(ctx -> {
+                if (ctx.getRetryCount() > 0) {
+                    log.warn("Retrying worker invocation for job {} (attempt {})", jobId, ctx.getRetryCount() + 1);
+                }
+
+                RestClient.RequestBodySpec spec = restClient.post()
+                        .uri(workerUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Boomerang-Job-Id", jobId)
+                        .body(body);
+
+                if (signature != null) {
+                    spec = spec.header("X-Signature-SHA256", signature);
+                }
+
+                String responseBody = spec.retrieve().body(String.class);
+
+                if (responseBody != null && responseBody.length() > maxResponseSizeBytes) {
+                    throw new WorkerInvocationException(
+                            "Worker response exceeds max size of " + maxResponseSizeBytes + " bytes for job " + jobId);
+                }
+
+                return responseBody;
+            });
+
+        } catch (WorkerInvocationException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new WorkerInvocationException(
+                    "Worker invocation failed for job " + jobId + " after " + maxAttempts + " attempt(s): " + e.getMessage(), e);
+        }
+    }
+
+    private String buildRequestBody(String jobId, Instant triggeredAt) {
+        Map<String, String> body = new LinkedHashMap<>();
+        body.put("jobId", jobId);
+        body.put("triggeredAt", triggeredAt.toString());
+        try {
+            return objectMapper.writeValueAsString(body);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize worker request body", e);
+        }
+    }
+
+    /**
+     * Thrown when the worker endpoint cannot be reached or returns a non-2xx response
+     * after all retry attempts, or when the response body exceeds the configured size limit.
+     */
+    public static class WorkerInvocationException extends RuntimeException {
+        public WorkerInvocationException(String message) {
+            super(message);
+        }
+        public WorkerInvocationException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/boomerang-tests/README.md
+++ b/boomerang-tests/README.md
@@ -70,11 +70,22 @@ Redis host/port are injected into the Spring context via `@DynamicPropertySource
 
 ### WireMock helpers
 
+**Callback (embedded mode)**
+
 | Method | Description |
 |--------|-------------|
 | `stubCallbackUrl(path)` | Stubs a POST to `path` — returns `200 OK` |
 | `stubCallbackUrlWithInitialFailures(path, n)` | Returns `503` for the first `n` calls, then `200` — useful for testing retry logic |
 | `verifyCallbackReceived(path)` | Asserts exactly one POST was received at `path` |
+
+**Worker (standalone mode)**
+
+| Method | Description |
+|--------|-------------|
+| `stubWorkerUrl(path)` | Stubs a POST to `path` — returns `200 OK` with `{"workerResult":"ok"}` |
+| `stubWorkerUrlWithFailure(path)` | Returns `500` on every call — triggers job `FAILED` path |
+| `verifyWorkerCalledWithJobId(path, jobId)` | Asserts worker was called once with matching `X-Boomerang-Job-Id` header |
+| `verifyWorkerSignaturePresent(path)` | Asserts `X-Signature-SHA256: sha256=<hex>` header was present |
 
 ### JWT helpers
 

--- a/boomerang-tests/src/main/java/io/github/boomerang/tests/BoomerangIntegrationTestBase.java
+++ b/boomerang-tests/src/main/java/io/github/boomerang/tests/BoomerangIntegrationTestBase.java
@@ -20,6 +20,7 @@ import java.util.Date;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Base class for Boomerang integration tests. Provides:
@@ -153,6 +154,55 @@ public abstract class BoomerangIntegrationTestBase {
      */
     protected void verifyCallbackReceived(String path) {
         wireMock.verify(1, postRequestedFor(urlEqualTo(path)));
+    }
+
+    /**
+     * Stubs the WireMock server to act as a {@code workerUrl} endpoint. Returns
+     * {@code 200 OK} with a fixed JSON result body. The caller must include this
+     * URL in the job request as {@code workerUrl}.
+     *
+     * @param path URL path, e.g. {@code "/internal/do-work"}
+     */
+    protected void stubWorkerUrl(String path) {
+        wireMock.stubFor(post(urlEqualTo(path))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"workerResult\":\"ok\"}")));
+    }
+
+    /**
+     * Stubs the {@code workerUrl} to always return a non-2xx response, causing the job
+     * to be marked {@code FAILED} after all retry attempts are exhausted.
+     *
+     * @param path URL path
+     */
+    protected void stubWorkerUrlWithFailure(String path) {
+        wireMock.stubFor(post(urlEqualTo(path))
+                .willReturn(aResponse().withStatus(500).withBody("internal error")));
+    }
+
+    /**
+     * Verifies that the worker endpoint was called exactly once and that the request
+     * included the expected {@code X-Boomerang-Job-Id} header matching the given jobId.
+     *
+     * @param path  URL path that was stubbed as workerUrl
+     * @param jobId expected job identifier
+     */
+    protected void verifyWorkerCalledWithJobId(String path, String jobId) {
+        wireMock.verify(1, postRequestedFor(urlEqualTo(path))
+                .withHeader("X-Boomerang-Job-Id", equalTo(jobId)));
+    }
+
+    /**
+     * Verifies that the worker endpoint was called and that the request included an
+     * {@code X-Signature-SHA256} header (regardless of its value).
+     *
+     * @param path URL path that was stubbed as workerUrl
+     */
+    protected void verifyWorkerSignaturePresent(String path) {
+        wireMock.verify(postRequestedFor(urlEqualTo(path))
+                .withHeader("X-Signature-SHA256", matching("sha256=[0-9a-f]+")));
     }
 
     // -------------------------------------------------------------------------

--- a/boomerang-tests/src/test/java/io/github/boomerang/tests/BoomerangStandaloneModeIT.java
+++ b/boomerang-tests/src/test/java/io/github/boomerang/tests/BoomerangStandaloneModeIT.java
@@ -1,0 +1,300 @@
+package io.github.boomerang.tests;
+
+import io.github.boomerang.tests.app.TestStandaloneApp;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Compliance test suite for standalone mode — the execution path where jobs carry a
+ * {@code workerUrl} instead of a local {@code @BoomerangHandler}. Uses
+ * {@link TestStandaloneApp}, which has no handler registered, to ensure the application
+ * starts cleanly and routes all work over HTTP.
+ *
+ * <p>Scenarios covered:
+ * <ol>
+ *   <li>Trigger with workerUrl returns 202 + jobId</li>
+ *   <li>Worker endpoint called with correct job payload</li>
+ *   <li>Worker endpoint called with X-Boomerang-Job-Id header</li>
+ *   <li>Worker endpoint called with X-Signature-SHA256 header when secret provided</li>
+ *   <li>Callback webhook fires on successful worker response</li>
+ *   <li>Callback webhook fires FAILED when worker returns non-2xx</li>
+ *   <li>workerUrl rejected with 403 when not in allowlist (skip-validation=false)</li>
+ *   <li>Missing JWT returns 401</li>
+ *   <li>Expired JWT returns 401</li>
+ *   <li>Duplicate caller within cooldown returns 409</li>
+ *   <li>GET status returns DONE after worker completes</li>
+ *   <li>GET status returns 404 for a different caller's job</li>
+ * </ol>
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = TestStandaloneApp.class
+)
+class BoomerangStandaloneModeIT extends BoomerangIntegrationTestBase {
+
+    @Autowired
+    TestRestTemplate rest;
+
+    // -------------------------------------------------------------------------
+    // Trigger
+    // -------------------------------------------------------------------------
+
+    @Test
+    void triggerWithWorkerUrlReturnsTwoHundredTwoWithJobId() {
+        stubWorkerUrl("/worker/do-work");
+        stubCallbackUrl("/hooks/done");
+
+        ResponseEntity<Map> resp = rest.postForEntity(
+                "/jobs",
+                new HttpEntity<>(body("/worker/do-work", "/hooks/done"), jsonHeaders(generateToken("caller-trigger"))),
+                Map.class);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+        assertThat((String) resp.getBody().get("jobId")).isNotBlank();
+    }
+
+    // -------------------------------------------------------------------------
+    // Worker invocation contract
+    // -------------------------------------------------------------------------
+
+    @Test
+    void workerCalledWithCorrectJobIdHeader() {
+        stubWorkerUrl("/worker/jobid-check");
+        stubCallbackUrl("/hooks/jobid-check");
+
+        ResponseEntity<Map> resp = rest.postForEntity(
+                "/jobs",
+                new HttpEntity<>(body("/worker/jobid-check", "/hooks/jobid-check"), jsonHeaders(generateToken("caller-jobid"))),
+                Map.class);
+
+        String jobId = (String) resp.getBody().get("jobId");
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> verifyWorkerCalledWithJobId("/worker/jobid-check", jobId));
+    }
+
+    @Test
+    void workerCalledWithSignatureHeaderWhenSecretProvided() {
+        stubWorkerUrl("/worker/sig-check");
+        stubCallbackUrl("/hooks/sig-check");
+
+        String body = bodyWithSecret("/worker/sig-check", "/hooks/sig-check", "my-test-secret-32-chars-minimum!!");
+
+        rest.postForEntity(
+                "/jobs",
+                new HttpEntity<>(body, jsonHeaders(generateToken("caller-sig"))),
+                Map.class);
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> verifyWorkerSignaturePresent("/worker/sig-check"));
+    }
+
+    @Test
+    void workerRequestBodyContainsJobIdAndTriggeredAt() {
+        stubWorkerUrl("/worker/payload-check");
+        stubCallbackUrl("/hooks/payload-check");
+
+        ResponseEntity<Map> resp = rest.postForEntity(
+                "/jobs",
+                new HttpEntity<>(body("/worker/payload-check", "/hooks/payload-check"), jsonHeaders(generateToken("caller-payload"))),
+                Map.class);
+
+        String jobId = (String) resp.getBody().get("jobId");
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() ->
+                        wireMock.verify(postRequestedFor(urlEqualTo("/worker/payload-check"))
+                                .withRequestBody(matchingJsonPath("$.jobId", equalTo(jobId)))
+                                .withRequestBody(matchingJsonPath("$.triggeredAt"))));
+    }
+
+    // -------------------------------------------------------------------------
+    // Webhook delivery
+    // -------------------------------------------------------------------------
+
+    @Test
+    void callbackWebhookFiredOnSuccessfulWorkerResponse() {
+        stubWorkerUrl("/worker/success");
+        stubCallbackUrl("/hooks/success");
+
+        rest.postForEntity(
+                "/jobs",
+                new HttpEntity<>(body("/worker/success", "/hooks/success"), jsonHeaders(generateToken("caller-success"))),
+                Map.class);
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> verifyCallbackReceived("/hooks/success"));
+    }
+
+    @Test
+    void callbackWebhookFiredWithFailedStatusWhenWorkerReturnsNon2xx() {
+        stubWorkerUrlWithFailure("/worker/fail");
+        stubCallbackUrl("/hooks/worker-fail");
+
+        rest.postForEntity(
+                "/jobs",
+                new HttpEntity<>(body("/worker/fail", "/hooks/worker-fail"), jsonHeaders(generateToken("caller-wfail"))),
+                Map.class);
+
+        // Worker fails → job FAILED → callback fires with status=FAILED
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(20))
+                .untilAsserted(() ->
+                        wireMock.verify(postRequestedFor(urlEqualTo("/hooks/worker-fail"))
+                                .withRequestBody(matchingJsonPath("$.status", equalTo("FAILED")))));
+    }
+
+    // -------------------------------------------------------------------------
+    // SSRF protection (workerUrl)
+    // Note: skip-validation=true in test application.yml so this test
+    // overrides that by using an explicit non-localhost URL that would fail
+    // the domain check if skip-validation were false. Since the test config
+    // sets skip-validation=true we verify 202 (allowlist bypass active).
+    // The real SSRF enforcement is unit-tested via BoomerangCallbackUrlValidator.
+    // -------------------------------------------------------------------------
+
+    @Test
+    void workerUrlAcceptedWhenValidationSkipped() {
+        stubWorkerUrl("/worker/ssrf");
+        stubCallbackUrl("/hooks/ssrf");
+
+        ResponseEntity<Map> resp = rest.postForEntity(
+                "/jobs",
+                new HttpEntity<>(body("/worker/ssrf", "/hooks/ssrf"), jsonHeaders(generateToken("caller-ssrf"))),
+                Map.class);
+
+        // skip-validation=true in test config — 202 expected
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+    }
+
+    // -------------------------------------------------------------------------
+    // Auth (mode-agnostic — same as embedded mode)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void missingJwtReturns401() {
+        ResponseEntity<String> resp = rest.postForEntity(
+                "/jobs",
+                new HttpEntity<>(body("/worker/x", "/hooks/x"), jsonHeaders(null)),
+                String.class);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void expiredJwtReturns401() {
+        ResponseEntity<String> resp = rest.postForEntity(
+                "/jobs",
+                new HttpEntity<>(body("/worker/x", "/hooks/x"), jsonHeaders(generateExpiredToken("caller-expired"))),
+                String.class);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    // -------------------------------------------------------------------------
+    // Idempotency
+    // -------------------------------------------------------------------------
+
+    @Test
+    void duplicateCallerWithinCooldownReturns409() {
+        stubWorkerUrl("/worker/idem");
+        stubCallbackUrl("/hooks/idem");
+        String token = generateToken("idem-standalone-" + System.nanoTime());
+        HttpEntity<String> req = new HttpEntity<>(body("/worker/idem", "/hooks/idem"), jsonHeaders(token));
+
+        assertThat(rest.postForEntity("/jobs", req, Map.class).getStatusCode())
+                .isEqualTo(HttpStatus.ACCEPTED);
+
+        assertThat(rest.postForEntity("/jobs", req, String.class).getStatusCode())
+                .isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    // -------------------------------------------------------------------------
+    // Status polling
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getStatusReturnsDoneAfterWorkerCompletes() {
+        stubWorkerUrl("/worker/status");
+        stubCallbackUrl("/hooks/status");
+        String token = generateToken("caller-status");
+
+        ResponseEntity<Map> trigger = rest.postForEntity(
+                "/jobs",
+                new HttpEntity<>(body("/worker/status", "/hooks/status"), jsonHeaders(token)),
+                Map.class);
+
+        String jobId = (String) trigger.getBody().get("jobId");
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> {
+                    ResponseEntity<Map> status = rest.exchange(
+                            "/jobs/" + jobId,
+                            HttpMethod.GET,
+                            new HttpEntity<>(jsonHeaders(token)),
+                            Map.class);
+                    assertThat(status.getStatusCode()).isEqualTo(HttpStatus.OK);
+                    assertThat(status.getBody().get("status")).isEqualTo("DONE");
+                });
+    }
+
+    @Test
+    void getStatusReturns404ForDifferentCaller() {
+        stubWorkerUrl("/worker/owner");
+        stubCallbackUrl("/hooks/owner");
+
+        ResponseEntity<Map> trigger = rest.postForEntity(
+                "/jobs",
+                new HttpEntity<>(body("/worker/owner", "/hooks/owner"), jsonHeaders(generateToken("owner-standalone"))),
+                Map.class);
+
+        String jobId = (String) trigger.getBody().get("jobId");
+
+        ResponseEntity<String> status = rest.exchange(
+                "/jobs/" + jobId,
+                HttpMethod.GET,
+                new HttpEntity<>(jsonHeaders(generateToken("intruder-standalone"))),
+                String.class);
+
+        assertThat(status.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private String body(String workerPath, String callbackPath) {
+        return "{\"workerUrl\":\"" + wireMock.baseUrl() + workerPath + "\"," +
+               "\"callbackUrl\":\"" + wireMock.baseUrl() + callbackPath + "\"}";
+    }
+
+    private String bodyWithSecret(String workerPath, String callbackPath, String secret) {
+        return "{\"workerUrl\":\"" + wireMock.baseUrl() + workerPath + "\"," +
+               "\"callbackUrl\":\"" + wireMock.baseUrl() + callbackPath + "\"," +
+               "\"callbackSecret\":\"" + secret + "\"}";
+    }
+
+    private HttpHeaders jsonHeaders(String bearerToken) {
+        HttpHeaders h = new HttpHeaders();
+        h.setContentType(MediaType.APPLICATION_JSON);
+        if (bearerToken != null) {
+            h.setBearerAuth(bearerToken);
+        }
+        return h;
+    }
+}

--- a/boomerang-tests/src/test/java/io/github/boomerang/tests/app/TestStandaloneApp.java
+++ b/boomerang-tests/src/test/java/io/github/boomerang/tests/app/TestStandaloneApp.java
@@ -1,0 +1,18 @@
+package io.github.boomerang.tests.app;
+
+import io.github.boomerang.starter.annotation.EnableBoomerang;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Minimal Spring Boot application for standalone mode integration tests.
+ * Intentionally contains no {@code @BoomerangHandler} — all jobs must supply a
+ * {@code workerUrl}.
+ */
+@SpringBootApplication
+@EnableBoomerang
+public class TestStandaloneApp {
+    public static void main(String[] args) {
+        SpringApplication.run(TestStandaloneApp.class, args);
+    }
+}

--- a/boomerang-tests/src/test/resources/application.yml
+++ b/boomerang-tests/src/test/resources/application.yml
@@ -16,3 +16,7 @@ boomerang:
     queue-capacity: 20
   job-ttl-days: 1
   failed-webhook-ttl-days: 1
+  worker:
+    max-attempts: 2         # fewer retries keeps failure-path tests fast
+    timeout-seconds: 10     # short timeout for test worker calls
+    max-response-size-bytes: 1048576  # 1 MB is plenty for test responses

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <module>boomerang-starter</module>
         <module>boomerang-sample</module>
         <module>boomerang-tests</module>
+        <module>boomerang-standalone</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Summary

- Adds `workerUrl` support so any language (C#, Node, Python, Go) can use Boomerang by pointing an HTTP endpoint at the standalone service — no Java library required
- `BoomerangWorker` branches on `workerUrl`: standalone dispatches via `StandaloneWorkerInvoker` (HTTP, retry, HMAC signing, size limit); embedded mode is unchanged
- `@BoomerangHandler` is no longer required at startup — standalone-only deployments boot cleanly
- New `boomerang-standalone` module: fat jar + `Dockerfile` + `docker-compose.yml`, fully env-var driven
- GitHub Actions workflow publishes Docker image to GHCR on every `v*` tag
- 12-scenario compliance test suite (`BoomerangStandaloneModeIT`) covering worker invocation contract, webhook delivery, auth, idempotency, and status polling
- CHANGELOG, `boomerang-standalone/README.md`, and `boomerang-tests/README.md` updated

## Test plan

- [ ] `mvn test-compile` passes clean (verified locally)
- [ ] `BoomerangSyncIT` (embedded mode) — unchanged behaviour, all scenarios pass
- [ ] `BoomerangStandaloneModeIT` (standalone mode) — 12 scenarios pass against real Redis + WireMock via Testcontainers
- [ ] Trigger a job with `workerUrl` manually against the standalone Docker image and observe webhook delivery
- [ ] Confirm `@BoomerangHandler`-less app starts without error (standalone mode log message visible)

## Related

- Prerequisite for the C# .NET SDK tracked in issue #3