### PR TITLE
Add Python SDK: signature, client, and webhook middleware

### DIFF
--- a/boomerang-python/pyproject.toml
+++ b/boomerang-python/pyproject.toml
@@ -11,12 +11,19 @@ license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.0,<3",
+    "httpx>=0.27,<1",
 ]
 
 [project.optional-dependencies]
+fastapi = ["fastapi>=0.100"]
+flask = ["flask>=2.0"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
+    "pytest-httpx>=0.30",
+    "fastapi>=0.100",
+    "flask>=2.0",
+    "httpx>=0.27,<1",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/boomerang-python/pyproject.toml
+++ b/boomerang-python/pyproject.toml
@@ -23,7 +23,6 @@ dev = [
     "pytest-httpx>=0.30",
     "fastapi>=0.100",
     "flask>=2.0",
-    "httpx>=0.27,<1",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/boomerang-python/src/boomerang/__init__.py
+++ b/boomerang-python/src/boomerang/__init__.py
@@ -1,3 +1,4 @@
+from .client import BoomerangClient
 from .errors import (
     BoomerangConflictError,
     BoomerangError,
@@ -11,8 +12,11 @@ from .models import (
     BoomerangTriggerRequest,
     BoomerangTriggerResponse,
 )
+from .signature import BoomerangSignature
 
 __all__ = [
+    "BoomerangClient",
+    "BoomerangSignature",
     "BoomerangError",
     "BoomerangUnauthorizedError",
     "BoomerangForbiddenError",

--- a/boomerang-python/src/boomerang/client.py
+++ b/boomerang-python/src/boomerang/client.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from urllib.parse import quote
+
+import httpx
+
+from .errors import (
+    BoomerangConflictError,
+    BoomerangError,
+    BoomerangForbiddenError,
+    BoomerangServiceUnavailableError,
+    BoomerangUnauthorizedError,
+)
+from .models import (
+    BoomerangJobStatus,
+    BoomerangTriggerRequest,
+    BoomerangTriggerResponse,
+)
+
+_STATUS_MAP: dict[int, type[BoomerangError]] = {
+    401: BoomerangUnauthorizedError,
+    403: BoomerangForbiddenError,
+    409: BoomerangConflictError,
+    503: BoomerangServiceUnavailableError,
+}
+
+
+class BoomerangClient:
+    """Thin HTTP client for the Boomerang async webhook service."""
+
+    def __init__(self, base_url: str, token: str) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._token = token
+
+    # --- headers ---
+
+    def _auth_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._token}",
+            "Content-Type": "application/json",
+        }
+
+    # --- error handling ---
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response) -> None:
+        if response.is_success:
+            return
+        body = response.json() if response.content else {}
+        message = body.get("error", response.reason_phrase or "Unknown error")
+        error_cls = _STATUS_MAP.get(response.status_code)
+        if error_cls is BoomerangConflictError:
+            raise BoomerangConflictError(
+                message,
+                retry_after_seconds=body.get("retryAfterSeconds"),
+            )
+        if error_cls is not None:
+            raise error_cls(message)
+        raise BoomerangError(response.status_code, message)
+
+    # --- sync ---
+
+    def trigger(
+        self,
+        worker_url: str,
+        callback_url: str,
+        callback_secret: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> BoomerangTriggerResponse:
+        """Submit a job via ``POST /sync``. Returns the assigned job ID."""
+        req = BoomerangTriggerRequest(
+            worker_url=worker_url,
+            callback_url=callback_url,
+            callback_secret=callback_secret,
+            idempotency_key=idempotency_key,
+        )
+        response = httpx.post(
+            f"{self._base_url}/sync",
+            headers=self._auth_headers(),
+            content=req.model_dump_json(by_alias=True, exclude_none=True),
+        )
+        self._raise_for_status(response)
+        return BoomerangTriggerResponse.model_validate(response.json())
+
+    def poll(self, job_id: str) -> BoomerangJobStatus:
+        """Poll job status via ``GET /sync/{jobId}``."""
+        response = httpx.get(
+            f"{self._base_url}/sync/{quote(job_id, safe='')}",
+            headers=self._auth_headers(),
+        )
+        self._raise_for_status(response)
+        return BoomerangJobStatus.model_validate(response.json())
+
+    # --- async ---
+
+    async def trigger_async(
+        self,
+        worker_url: str,
+        callback_url: str,
+        callback_secret: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> BoomerangTriggerResponse:
+        """Async variant of :meth:`trigger`."""
+        req = BoomerangTriggerRequest(
+            worker_url=worker_url,
+            callback_url=callback_url,
+            callback_secret=callback_secret,
+            idempotency_key=idempotency_key,
+        )
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self._base_url}/sync",
+                headers=self._auth_headers(),
+                content=req.model_dump_json(by_alias=True, exclude_none=True),
+            )
+        self._raise_for_status(response)
+        return BoomerangTriggerResponse.model_validate(response.json())
+
+    async def poll_async(self, job_id: str) -> BoomerangJobStatus:
+        """Async variant of :meth:`poll`."""
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{self._base_url}/sync/{quote(job_id, safe='')}",
+                headers=self._auth_headers(),
+            )
+        self._raise_for_status(response)
+        return BoomerangJobStatus.model_validate(response.json())

--- a/boomerang-python/src/boomerang/client.py
+++ b/boomerang-python/src/boomerang/client.py
@@ -31,6 +31,8 @@ class BoomerangClient:
     def __init__(self, base_url: str, token: str) -> None:
         self._base_url = base_url.rstrip("/")
         self._token = token
+        self._client = httpx.Client()
+        self._async_client = httpx.AsyncClient()
 
     # --- headers ---
 
@@ -46,7 +48,10 @@ class BoomerangClient:
     def _raise_for_status(response: httpx.Response) -> None:
         if response.is_success:
             return
-        body = response.json() if response.content else {}
+        try:
+            body = response.json() if response.content else {}
+        except Exception:
+            body = {}
         message = body.get("error", response.reason_phrase or "Unknown error")
         error_cls = _STATUS_MAP.get(response.status_code)
         if error_cls is BoomerangConflictError:
@@ -74,7 +79,7 @@ class BoomerangClient:
             callback_secret=callback_secret,
             idempotency_key=idempotency_key,
         )
-        response = httpx.post(
+        response = self._client.post(
             f"{self._base_url}/sync",
             headers=self._auth_headers(),
             content=req.model_dump_json(by_alias=True, exclude_none=True),
@@ -84,7 +89,7 @@ class BoomerangClient:
 
     def poll(self, job_id: str) -> BoomerangJobStatus:
         """Poll job status via ``GET /sync/{jobId}``."""
-        response = httpx.get(
+        response = self._client.get(
             f"{self._base_url}/sync/{quote(job_id, safe='')}",
             headers=self._auth_headers(),
         )
@@ -107,21 +112,19 @@ class BoomerangClient:
             callback_secret=callback_secret,
             idempotency_key=idempotency_key,
         )
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                f"{self._base_url}/sync",
-                headers=self._auth_headers(),
-                content=req.model_dump_json(by_alias=True, exclude_none=True),
-            )
+        response = await self._async_client.post(
+            f"{self._base_url}/sync",
+            headers=self._auth_headers(),
+            content=req.model_dump_json(by_alias=True, exclude_none=True),
+        )
         self._raise_for_status(response)
         return BoomerangTriggerResponse.model_validate(response.json())
 
     async def poll_async(self, job_id: str) -> BoomerangJobStatus:
         """Async variant of :meth:`poll`."""
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                f"{self._base_url}/sync/{quote(job_id, safe='')}",
-                headers=self._auth_headers(),
-            )
+        response = await self._async_client.get(
+            f"{self._base_url}/sync/{quote(job_id, safe='')}",
+            headers=self._auth_headers(),
+        )
         self._raise_for_status(response)
         return BoomerangJobStatus.model_validate(response.json())

--- a/boomerang-python/src/boomerang/client.py
+++ b/boomerang-python/src/boomerang/client.py
@@ -34,6 +34,28 @@ class BoomerangClient:
         self._client = httpx.Client()
         self._async_client = httpx.AsyncClient()
 
+    # --- lifecycle ---
+
+    def close(self) -> None:
+        """Close the underlying connection pools."""
+        self._client.close()
+
+    async def aclose(self) -> None:
+        """Close the underlying async connection pool."""
+        await self._async_client.aclose()
+
+    def __enter__(self) -> BoomerangClient:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    async def __aenter__(self) -> BoomerangClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.aclose()
+
     # --- headers ---
 
     def _auth_headers(self) -> dict[str, str]:

--- a/boomerang-python/src/boomerang/middleware/fastapi.py
+++ b/boomerang-python/src/boomerang/middleware/fastapi.py
@@ -1,0 +1,42 @@
+"""FastAPI dependency for verifying Boomerang webhook signatures."""
+
+from typing import Callable
+
+from ..models import BoomerangPayload
+from ..signature import BoomerangSignature
+
+
+def boomerang_webhook(secret: str) -> Callable:
+    """Return a FastAPI dependency callable that verifies the webhook
+    signature and returns a :class:`BoomerangPayload`.
+
+    Usage::
+
+        from fastapi import Depends
+
+        @app.post("/hooks/sync-done")
+        async def on_sync_done(
+            payload: BoomerangPayload = Depends(boomerang_webhook(secret)),
+        ):
+            ...
+    """
+    from fastapi import HTTPException, Request
+
+    async def _verify(request: Request) -> BoomerangPayload:
+        signature = request.headers.get("x-signature-sha256")
+        if not signature:
+            raise HTTPException(status_code=401, detail="Missing X-Signature-SHA256 header")
+
+        body = await request.body()
+
+        try:
+            valid = BoomerangSignature.verify(body, signature, secret)
+        except ValueError:
+            raise HTTPException(status_code=401, detail="Malformed signature header")
+
+        if not valid:
+            raise HTTPException(status_code=401, detail="Invalid signature")
+
+        return BoomerangPayload.model_validate_json(body)
+
+    return _verify

--- a/boomerang-python/src/boomerang/middleware/flask.py
+++ b/boomerang-python/src/boomerang/middleware/flask.py
@@ -26,7 +26,7 @@ def boomerang_webhook(secret: str) -> Callable:
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             from flask import abort, request  # noqa: lazy import
 
-            signature = request.headers.get("X-Signature-SHA256")
+            signature = request.headers.get("x-signature-sha256")
             if not signature:
                 abort(401, description="Missing X-Signature-SHA256 header")
 

--- a/boomerang-python/src/boomerang/middleware/flask.py
+++ b/boomerang-python/src/boomerang/middleware/flask.py
@@ -1,0 +1,48 @@
+"""Flask decorator for verifying Boomerang webhook signatures."""
+
+from __future__ import annotations
+
+import functools
+from typing import Any, Callable
+
+from ..models import BoomerangPayload
+from ..signature import BoomerangSignature
+
+
+def boomerang_webhook(secret: str) -> Callable:
+    """Decorator that verifies the webhook signature and injects a
+    :class:`BoomerangPayload` as the first positional argument.
+
+    Usage::
+
+        @app.post("/hooks/sync-done")
+        @boomerang_webhook(secret=os.environ["WEBHOOK_SECRET"])
+        def on_sync_done(payload: BoomerangPayload):
+            ...
+    """
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            from flask import abort, request  # noqa: lazy import
+
+            signature = request.headers.get("X-Signature-SHA256")
+            if not signature:
+                abort(401, description="Missing X-Signature-SHA256 header")
+
+            body = request.get_data()
+
+            try:
+                valid = BoomerangSignature.verify(body, signature, secret)
+            except ValueError:
+                abort(401, description="Malformed signature header")
+
+            if not valid:
+                abort(401, description="Invalid signature")
+
+            payload = BoomerangPayload.model_validate_json(body)
+            return fn(payload, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/boomerang-python/src/boomerang/signature.py
+++ b/boomerang-python/src/boomerang/signature.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+
+class BoomerangSignature:
+    """HMAC-SHA256 signature verification for Boomerang webhooks."""
+
+    _PREFIX = "sha256="
+
+    @staticmethod
+    def verify(body: bytes, signature_header: str, secret: str) -> bool:
+        """Return ``True`` if *signature_header* is a valid HMAC for *body*.
+
+        Uses constant-time comparison to prevent timing attacks.
+
+        Raises ``ValueError`` if *signature_header* does not start with
+        ``sha256=``.
+        """
+        if not signature_header.startswith(BoomerangSignature._PREFIX):
+            raise ValueError(
+                f"Malformed signature header: expected 'sha256=...' prefix, "
+                f"got {signature_header!r}"
+            )
+        expected = BoomerangSignature.compute(body, secret)
+        return hmac.compare_digest(expected, signature_header)
+
+    @staticmethod
+    def compute(body: bytes, secret: str) -> str:
+        """Return the signature header value: ``sha256=<lowercase hex>``."""
+        digest = hmac.new(
+            secret.encode("utf-8"),
+            body,
+            hashlib.sha256,
+        ).hexdigest()
+        return f"sha256={digest}"

--- a/boomerang-python/tests/test_client.py
+++ b/boomerang-python/tests/test_client.py
@@ -1,0 +1,206 @@
+import json
+
+import httpx
+import pytest
+
+from boomerang import (
+    BoomerangConflictError,
+    BoomerangForbiddenError,
+    BoomerangServiceUnavailableError,
+    BoomerangUnauthorizedError,
+)
+from boomerang.client import BoomerangClient
+
+
+BASE = "https://boomerang.test"
+TOKEN = "test-jwt"
+
+
+def _client() -> BoomerangClient:
+    return BoomerangClient(base_url=BASE, token=TOKEN)
+
+
+def _mock_response(status: int, body: dict | None = None) -> httpx.Response:
+    return httpx.Response(
+        status_code=status,
+        json=body or {},
+        request=httpx.Request("GET", BASE),
+    )
+
+
+# ── trigger ──────────────────────────────────────────────────────────
+
+
+class TestTrigger:
+    def test_success(self, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE}/sync",
+            method="POST",
+            status_code=202,
+            json={"jobId": "j1"},
+        )
+        resp = _client().trigger(
+            worker_url="https://w.co/work",
+            callback_url="https://c.co/hook",
+        )
+        assert resp.job_id == "j1"
+
+    def test_sends_auth_header(self, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE}/sync",
+            method="POST",
+            status_code=202,
+            json={"jobId": "j1"},
+        )
+        _client().trigger(
+            worker_url="https://w.co/work",
+            callback_url="https://c.co/hook",
+        )
+        request = httpx_mock.get_request()
+        assert request.headers["authorization"] == f"Bearer {TOKEN}"
+
+    def test_sends_camel_case_body(self, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE}/sync",
+            method="POST",
+            status_code=202,
+            json={"jobId": "j1"},
+        )
+        _client().trigger(
+            worker_url="https://w.co/work",
+            callback_url="https://c.co/hook",
+            callback_secret="s",
+            idempotency_key="k",
+        )
+        body = json.loads(httpx_mock.get_request().content)
+        assert body == {
+            "workerUrl": "https://w.co/work",
+            "callbackUrl": "https://c.co/hook",
+            "callbackSecret": "s",
+            "idempotencyKey": "k",
+        }
+
+    def test_excludes_none_fields(self, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE}/sync",
+            method="POST",
+            status_code=202,
+            json={"jobId": "j1"},
+        )
+        _client().trigger(
+            worker_url="https://w.co/work",
+            callback_url="https://c.co/hook",
+        )
+        body = json.loads(httpx_mock.get_request().content)
+        assert "callbackSecret" not in body
+        assert "idempotencyKey" not in body
+
+
+# ── poll ─────────────────────────────────────────────────────────────
+
+
+class TestPoll:
+    def test_success(self, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE}/sync/j1",
+            method="GET",
+            json={"jobId": "j1", "status": "DONE", "completedAt": "2026-01-01T00:00:00Z"},
+        )
+        status = _client().poll("j1")
+        assert status.job_id == "j1"
+        assert status.status == "DONE"
+
+    def test_url_encodes_job_id(self, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE}/sync/a%2Fb",
+            method="GET",
+            json={"jobId": "a/b", "status": "PENDING"},
+        )
+        status = _client().poll("a/b")
+        assert status.job_id == "a/b"
+
+
+# ── error mapping ───────────────────────────────────────────────────
+
+
+class TestErrorMapping:
+    @pytest.mark.parametrize(
+        "status,error_cls",
+        [
+            (401, BoomerangUnauthorizedError),
+            (403, BoomerangForbiddenError),
+            (409, BoomerangConflictError),
+            (503, BoomerangServiceUnavailableError),
+        ],
+    )
+    def test_known_errors(self, httpx_mock, status, error_cls):
+        httpx_mock.add_response(
+            url=f"{BASE}/sync",
+            method="POST",
+            status_code=status,
+            json={"error": "boom"},
+        )
+        with pytest.raises(error_cls, match="boom"):
+            _client().trigger(
+                worker_url="https://w.co/work",
+                callback_url="https://c.co/hook",
+            )
+
+    def test_conflict_retry_after(self, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE}/sync",
+            method="POST",
+            status_code=409,
+            json={"error": "dup", "retryAfterSeconds": 30},
+        )
+        with pytest.raises(BoomerangConflictError) as exc_info:
+            _client().trigger(
+                worker_url="https://w.co/work",
+                callback_url="https://c.co/hook",
+            )
+        assert exc_info.value.retry_after_seconds == 30
+
+    def test_unknown_error(self, httpx_mock):
+        from boomerang.errors import BoomerangError
+
+        httpx_mock.add_response(
+            url=f"{BASE}/sync",
+            method="POST",
+            status_code=500,
+            json={"error": "internal"},
+        )
+        with pytest.raises(BoomerangError) as exc_info:
+            _client().trigger(
+                worker_url="https://w.co/work",
+                callback_url="https://c.co/hook",
+            )
+        assert exc_info.value.status_code == 500
+
+
+# ── async ────────────────────────────────────────────────────────────
+
+
+class TestAsync:
+    @pytest.mark.asyncio
+    async def test_trigger_async(self, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE}/sync",
+            method="POST",
+            status_code=202,
+            json={"jobId": "j1"},
+        )
+        resp = await _client().trigger_async(
+            worker_url="https://w.co/work",
+            callback_url="https://c.co/hook",
+        )
+        assert resp.job_id == "j1"
+
+    @pytest.mark.asyncio
+    async def test_poll_async(self, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE}/sync/j1",
+            method="GET",
+            json={"jobId": "j1", "status": "PENDING"},
+        )
+        status = await _client().poll_async("j1")
+        assert status.status == "PENDING"

--- a/boomerang-python/tests/test_middleware_fastapi.py
+++ b/boomerang-python/tests/test_middleware_fastapi.py
@@ -1,0 +1,68 @@
+import json
+
+import pytest
+
+from boomerang.signature import BoomerangSignature
+
+SECRET = "test-secret"
+PAYLOAD = {
+    "boomerangVersion": "1",
+    "jobId": "j1",
+    "status": "DONE",
+    "completedAt": "2026-03-22T10:00:18Z",
+    "result": {"key": "value"},
+}
+BODY = json.dumps(PAYLOAD).encode()
+VALID_SIG = BoomerangSignature.compute(BODY, SECRET)
+
+
+@pytest.fixture()
+def fastapi_client():
+    from fastapi import Depends, FastAPI
+    from fastapi.testclient import TestClient
+
+    from boomerang.middleware.fastapi import boomerang_webhook
+    from boomerang.models import BoomerangPayload
+
+    app = FastAPI()
+
+    @app.post("/hooks")
+    async def hook(payload: BoomerangPayload = Depends(boomerang_webhook(SECRET))):
+        return {"job_id": payload.job_id, "status": payload.status}
+
+    return TestClient(app)
+
+
+class TestFastAPIMiddleware:
+    def test_valid_signature(self, fastapi_client):
+        resp = fastapi_client.post(
+            "/hooks",
+            content=BODY,
+            headers={"X-Signature-SHA256": VALID_SIG, "Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["job_id"] == "j1"
+
+    def test_missing_signature_returns_401(self, fastapi_client):
+        resp = fastapi_client.post(
+            "/hooks",
+            content=BODY,
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 401
+
+    def test_invalid_signature_returns_401(self, fastapi_client):
+        resp = fastapi_client.post(
+            "/hooks",
+            content=BODY,
+            headers={"X-Signature-SHA256": "sha256=" + "a" * 64, "Content-Type": "application/json"},
+        )
+        assert resp.status_code == 401
+
+    def test_malformed_signature_returns_401(self, fastapi_client):
+        resp = fastapi_client.post(
+            "/hooks",
+            content=BODY,
+            headers={"X-Signature-SHA256": "bad", "Content-Type": "application/json"},
+        )
+        assert resp.status_code == 401

--- a/boomerang-python/tests/test_middleware_flask.py
+++ b/boomerang-python/tests/test_middleware_flask.py
@@ -1,0 +1,69 @@
+import json
+
+import pytest
+
+from boomerang.signature import BoomerangSignature
+
+SECRET = "test-secret"
+PAYLOAD = {
+    "boomerangVersion": "1",
+    "jobId": "j1",
+    "status": "DONE",
+    "completedAt": "2026-03-22T10:00:18Z",
+    "result": {"key": "value"},
+}
+BODY = json.dumps(PAYLOAD).encode()
+VALID_SIG = BoomerangSignature.compute(BODY, SECRET)
+
+
+@pytest.fixture()
+def flask_client():
+    from flask import Flask, jsonify
+
+    from boomerang.middleware.flask import boomerang_webhook
+    from boomerang.models import BoomerangPayload
+
+    app = Flask(__name__)
+
+    @app.post("/hooks")
+    @boomerang_webhook(secret=SECRET)
+    def hook(payload: BoomerangPayload):
+        return jsonify(job_id=payload.job_id, status=payload.status)
+
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+class TestFlaskMiddleware:
+    def test_valid_signature(self, flask_client):
+        resp = flask_client.post(
+            "/hooks",
+            data=BODY,
+            headers={"X-Signature-SHA256": VALID_SIG, "Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["job_id"] == "j1"
+
+    def test_missing_signature_returns_401(self, flask_client):
+        resp = flask_client.post(
+            "/hooks",
+            data=BODY,
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 401
+
+    def test_invalid_signature_returns_401(self, flask_client):
+        resp = flask_client.post(
+            "/hooks",
+            data=BODY,
+            headers={"X-Signature-SHA256": "sha256=" + "a" * 64, "Content-Type": "application/json"},
+        )
+        assert resp.status_code == 401
+
+    def test_malformed_signature_returns_401(self, flask_client):
+        resp = flask_client.post(
+            "/hooks",
+            data=BODY,
+            headers={"X-Signature-SHA256": "bad", "Content-Type": "application/json"},
+        )
+        assert resp.status_code == 401

--- a/boomerang-python/tests/test_signature.py
+++ b/boomerang-python/tests/test_signature.py
@@ -1,0 +1,66 @@
+import hashlib
+import hmac
+
+import pytest
+
+from boomerang.signature import BoomerangSignature
+
+
+SECRET = "test-secret"
+BODY = b'{"jobId":"abc-123","status":"DONE"}'
+
+
+def _expected_sig(body: bytes = BODY, secret: str = SECRET) -> str:
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+class TestCompute:
+    def test_returns_sha256_prefix(self):
+        result = BoomerangSignature.compute(BODY, SECRET)
+        assert result.startswith("sha256=")
+
+    def test_lowercase_hex(self):
+        result = BoomerangSignature.compute(BODY, SECRET)
+        hex_part = result.removeprefix("sha256=")
+        assert hex_part == hex_part.lower()
+        assert len(hex_part) == 64  # SHA-256 = 64 hex chars
+
+    def test_matches_stdlib_hmac(self):
+        assert BoomerangSignature.compute(BODY, SECRET) == _expected_sig()
+
+    def test_different_secret_different_sig(self):
+        sig1 = BoomerangSignature.compute(BODY, "secret-a")
+        sig2 = BoomerangSignature.compute(BODY, "secret-b")
+        assert sig1 != sig2
+
+    def test_different_body_different_sig(self):
+        sig1 = BoomerangSignature.compute(b"body-a", SECRET)
+        sig2 = BoomerangSignature.compute(b"body-b", SECRET)
+        assert sig1 != sig2
+
+
+class TestVerify:
+    def test_valid_signature(self):
+        sig = _expected_sig()
+        assert BoomerangSignature.verify(BODY, sig, SECRET) is True
+
+    def test_invalid_signature(self):
+        bad_sig = "sha256=" + "a" * 64
+        assert BoomerangSignature.verify(BODY, bad_sig, SECRET) is False
+
+    def test_wrong_secret(self):
+        sig = _expected_sig(secret="wrong")
+        assert BoomerangSignature.verify(BODY, sig, SECRET) is False
+
+    def test_malformed_header_raises(self):
+        with pytest.raises(ValueError, match="Malformed signature header"):
+            BoomerangSignature.verify(BODY, "bad-header", SECRET)
+
+    def test_empty_prefix_raises(self):
+        with pytest.raises(ValueError):
+            BoomerangSignature.verify(BODY, "abcdef1234", SECRET)
+
+    def test_empty_body(self):
+        sig = BoomerangSignature.compute(b"", SECRET)
+        assert BoomerangSignature.verify(b"", sig, SECRET) is True


### PR DESCRIPTION
## Summary
Completes the remaining Python SDK components in a single branch (3 commits, one per issue):

- **#16 — BoomerangSignature**: HMAC-SHA256 `verify()` and `compute()` with constant-time comparison via `hmac.compare_digest`. Raises `ValueError` on malformed headers. (11 tests)
- **#14 — BoomerangClient**: Sync `trigger()`/`poll()` and async `trigger_async()`/`poll_async()` using `httpx`. Auto-injects Bearer auth, maps HTTP errors to typed exceptions. (14 tests)
- **#17 — FastAPI & Flask middleware**: FastAPI `Depends()`-based dependency and Flask decorator that verify webhook signatures and inject `BoomerangPayload`. Return 401 on missing/invalid signatures. (8 tests)

**62 total unit tests, all passing.**

## Test plan
- [x] `pytest tests/ -v` — 62 passed
- [x] Signature matches stdlib `hmac` output
- [x] Client sends camelCase JSON, receives typed responses
- [x] Client raises correct exception subclass for 401/403/409/503
- [x] FastAPI middleware returns 401 for missing/invalid/malformed signatures
- [x] Flask decorator returns 401 for missing/invalid/malformed signatures

Closes #11, closes #14, closes #16, closes #17, closes #19